### PR TITLE
Implement unidling on receiving HTTP request

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ MAINTAINER Andy Driver <andy.driver@digital.justice.gov.uk>
 
 WORKDIR /home/unidler
 
+ADD requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
 ADD unidler.py unidler.py
 
 CMD ["python", "unidler.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+kubernetes==4.0.0

--- a/test/test_unidler.py
+++ b/test/test_unidler.py
@@ -110,7 +110,7 @@ def test_write_changes(client, deployment):
     unidler.write_changes(deployment)
 
     api = client.AppsV1beta1Api.return_value
-    api.patch_namespaced_deployment.assert_called_with(
+    api.replace_namespaced_deployment.assert_called_with(
         deployment.metadata.name,
         deployment.metadata.namespace,
         deployment)
@@ -125,7 +125,7 @@ def test_deployment_for_ingress(client, deployment, ingress):
             ingress.metadata.name,
             ingress.metadata.namespace)
 
-    api.patch_namespaced_deployment.assert_called_with(
+    api.replace_namespaced_deployment.assert_called_with(
         deployment.metadata.name,
         deployment.metadata.namespace,
         deployment)
@@ -171,7 +171,7 @@ def test_unidle_deployment(client, deployment, ingress, unidler_ingress):
 
         unidler.unidle_deployment(HOSTNAME)
 
-        apps.patch_namespaced_deployment.assert_called_with(
+        apps.replace_namespaced_deployment.assert_called_with(
             deployment.metadata.name,
             deployment.metadata.namespace,
             deployment)

--- a/test/test_unidler.py
+++ b/test/test_unidler.py
@@ -68,15 +68,11 @@ def unidler_ingress():
 
 
 def test_remove_host_rule(unidler_ingress):
-    assert len(list(filter(
-        lambda rule: rule.host == HOSTNAME,
-        unidler_ingress.spec.rules))) == 1
+    assert any(rule.host == HOSTNAME for rule in unidler_ingress.spec.rules)
 
     unidler.remove_host_rule(HOSTNAME, unidler_ingress)
 
-    assert len(list(filter(
-        lambda rule: rule.host == HOSTNAME,
-        unidler_ingress.spec.rules))) == 0
+    assert all(rule.host != HOSTNAME for rule in unidler_ingress.spec.rules)
 
 
 def test_unmark_idled(deployment):
@@ -106,8 +102,8 @@ def test_restore_replicas(deployment):
     assert deployment.spec.replicas == 2
 
 
-def test_write_changes(client, deployment):
-    unidler.write_changes(deployment)
+def test_write_deployment_changes(client, deployment):
+    unidler.write_deployment_changes(deployment)
 
     api = client.AppsV1beta1Api.return_value
     api.replace_namespaced_deployment.assert_called_with(

--- a/test/test_unidler.py
+++ b/test/test_unidler.py
@@ -1,0 +1,253 @@
+from io import BytesIO
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+import unidler
+from unidler import (
+    IDLED,
+    IDLED_AT,
+    INGRESS_CLASS,
+    RequestHandler,
+    UNIDLER,
+)
+
+
+HOSTNAME = 'test.host.name'
+
+
+@pytest.yield_fixture
+def client():
+    client = MagicMock()
+    with patch('unidler.client', client):
+        yield client
+
+
+@pytest.fixture
+def deployment():
+    deployment = MagicMock()
+    deployment.spec.replicas = 0
+    deployment.metadata.labels = {
+        IDLED: 'true',
+    }
+    deployment.metadata.annotations = {
+        IDLED_AT: 'YYYY-mm-ddTHH:MM:SS+0000,2',
+    }
+    deployment.metadata.name = 'test-app'
+    deployment.metadata.namespace = 'test-namespace'
+    return deployment
+
+
+@pytest.fixture
+def ingress():
+    host_rule = MagicMock()
+    host_rule.host = HOSTNAME
+    ingress = MagicMock()
+    ingress.spec.rules = [
+        host_rule,
+    ]
+    ingress.metadata.annotations = {
+        INGRESS_CLASS: 'disabled',
+    }
+    ingress.metadata.name = 'test-app'
+    ingress.metadata.namespace = 'test-namespace'
+    return ingress
+
+
+@pytest.fixture
+def unidler_ingress():
+    host_rule = MagicMock()
+    host_rule.host = HOSTNAME
+    ingress = MagicMock()
+    ingress.spec.rules = [
+        host_rule,
+    ]
+    ingress.metadata.name = UNIDLER
+    ingress.metadata.namespace = 'default'
+    return ingress
+
+
+def test_remove_host_rule(unidler_ingress):
+    assert len(list(filter(
+        lambda rule: rule.host == HOSTNAME,
+        unidler_ingress.spec.rules))) == 1
+
+    unidler.remove_host_rule(HOSTNAME, unidler_ingress)
+
+    assert len(list(filter(
+        lambda rule: rule.host == HOSTNAME,
+        unidler_ingress.spec.rules))) == 0
+
+
+def test_unmark_idled(deployment):
+    assert IDLED in deployment.metadata.labels
+    assert IDLED_AT in deployment.metadata.annotations
+
+    unidler.unmark_idled(deployment)
+
+    assert IDLED not in deployment.metadata.labels
+    assert IDLED_AT not in deployment.metadata.annotations
+
+
+def test_enable_ingress(ingress):
+    assert ingress.metadata.annotations[INGRESS_CLASS] == 'disabled'
+
+    unidler.enable_ingress(ingress)
+
+    assert ingress.metadata.annotations[INGRESS_CLASS] == 'nginx'
+
+
+def test_restore_replicas(deployment):
+    assert deployment.spec.replicas == 0
+    assert deployment.metadata.annotations[IDLED_AT].split(',')[1] == '2'
+
+    unidler.restore_replicas(deployment)
+
+    assert deployment.spec.replicas == 2
+
+
+def test_write_changes(client, deployment):
+    unidler.write_changes(deployment)
+
+    api = client.AppsV1beta1Api.return_value
+    api.patch_namespaced_deployment.assert_called_with(
+        deployment.metadata.name,
+        deployment.metadata.namespace,
+        deployment)
+
+
+def test_deployment_for_ingress(client, deployment, ingress):
+    api = client.AppsV1beta1Api.return_value
+    api.read_namespaced_deployment.return_value = deployment
+
+    with unidler.deployment_for_ingress(ingress):
+        api.read_namespaced_deployment.assert_called_with(
+            ingress.metadata.name,
+            ingress.metadata.namespace)
+
+    api.patch_namespaced_deployment.assert_called_with(
+        deployment.metadata.name,
+        deployment.metadata.namespace,
+        deployment)
+
+
+def test_write_ingress_changes(client, ingress):
+    api = client.ExtensionsV1beta1Api.return_value
+
+    unidler.write_ingress_changes(ingress)
+
+    api.patch_namespaced_ingress.assert_called_with(
+        ingress.metadata.name,
+        ingress.metadata.namespace,
+        ingress)
+
+
+def test_ingress_for_host(client, ingress, unidler_ingress):
+    api = client.ExtensionsV1beta1Api.return_value
+    ingresses = {
+        (ingress.metadata.name, ingress.metadata.namespace): ingress,
+        (UNIDLER, 'default'): unidler_ingress,
+    }
+    with unidler.ingress_for_host(HOSTNAME, ingresses) as ing:
+        assert ing.metadata.name == ingress.metadata.name
+        assert ing.metadata.namespace == ingress.metadata.namespace
+
+    api.patch_namespaced_ingress.assert_called_with(
+        ingress.metadata.name,
+        ingress.metadata.namespace,
+        ingress)
+
+
+def test_unidle_deployment(client, deployment, ingress, unidler_ingress):
+    apps = client.AppsV1beta1Api.return_value
+    apps.read_namespaced_deployment.return_value = deployment
+    extensions = client.ExtensionsV1beta1Api.return_value
+
+    with patch('unidler.build_ingress_lookup') as ingresses:
+        ingresses.return_value = {
+            (ingress.metadata.name, ingress.metadata.namespace): ingress,
+            (UNIDLER, 'default'): unidler_ingress,
+        }
+
+        unidler.unidle_deployment(HOSTNAME)
+
+        apps.patch_namespaced_deployment.assert_called_with(
+            deployment.metadata.name,
+            deployment.metadata.namespace,
+            deployment)
+        assert IDLED not in deployment.metadata.labels
+        assert IDLED_AT not in deployment.metadata.annotations
+        assert deployment.spec.replicas == 2
+
+        assert extensions.patch_namespaced_ingress.mock_calls == [
+            call(
+                ingress.metadata.name,
+                ingress.metadata.namespace,
+                ingress),
+            call(
+                unidler_ingress.metadata.name,
+                unidler_ingress.metadata.namespace,
+                unidler_ingress),
+        ]
+        assert ingress.metadata.annotations[INGRESS_CLASS] == 'nginx'
+
+        assert len(list(filter(
+            lambda rule: rule.host == HOSTNAME,
+            unidler_ingress.spec.rules))) == 0
+
+
+class TestRequestHandler(object):
+
+    def test_doGET(self, client, deployment, ingress, unidler_ingress):
+        assert IDLED_AT in deployment.metadata.annotations
+
+        apps = client.AppsV1beta1Api.return_value
+        extensions = client.ExtensionsV1beta1Api.return_value
+
+        ingresses = MagicMock()
+        ingresses.items = [ingress, unidler_ingress]
+        extensions.list_ingress_for_all_namespaces.return_value = ingresses
+
+        apps.read_namespaced_deployment.return_value = deployment
+
+        response = self.handle_request('GET', '/', {
+            'X-Forwarded-Host': HOSTNAME,
+        })
+        assert response.status_code == 503
+        assert IDLED not in deployment.metadata.labels
+        assert IDLED_AT not in deployment.metadata.annotations
+        assert deployment.spec.replicas == 2
+        assert ingress.metadata.annotations[INGRESS_CLASS] == 'nginx'
+
+        assert len(list(filter(
+            lambda rule: rule.host == HOSTNAME,
+            unidler_ingress.spec.rules))) == 0
+
+    def handle_request(self, method, path, headers={}):
+        request = f'{method} {path} HTTP/1.0\n'
+        request += '\n'.join(
+            f'{header}: {value}' for header, value in headers.items())
+        mock = MagicMock()
+        mock.makefile.return_value = BytesIO(request.encode('iso-8859-1'))
+        self.server = MagicMock()
+        with patch('socketserver._SocketWriter') as SocketWriter:
+            writer = SocketWriter.return_value
+            self.handler = RequestHandler(mock, ('0.0.0.0', 8888), self.server)
+            return self.parse_response(writer.write.mock_calls)
+
+    def parse_response(self, calls):
+        res = MagicMock()
+        response = ''.join(
+            call[1][0].decode('utf-8')
+            for call in calls)
+        response = response.split('\r\n')
+        status, response = response[:1][0], response[1:]
+        res.status = status = status.split(' ', 1)[1]
+        res.status_code = int(status.split(' ')[0])
+        res.headers = {}
+        line, response = response[:1][0], response[1:]
+        while line:
+            res.headers.update((line.split(': ', 1),))
+            line, response = response[:1][0], response[1:]
+        res.body = ''.join(response)
+        return res

--- a/unidler.py
+++ b/unidler.py
@@ -1,3 +1,4 @@
+import contextlib
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import logging
 import os
@@ -6,36 +7,70 @@ from socketserver import ThreadingMixIn
 import ssl
 import sys
 
-# import kubernetes
-# import requests
+import kubernetes
+from kubernetes import client, config
+from kubernetes.client.models import (
+    V1beta1HTTPIngressPath,
+    V1beta1HTTPIngressRuleValue,
+    V1beta1IngressBackend,
+    V1beta1IngressRule,
+)
+
+
+IDLED = 'mojanalytics.xyz/idled'
+IDLED_AT = 'mojanalytics.xyz/idled-at'
+INGRESS_CLASS = 'kubernetes.io/ingress.class'
+UNIDLER = 'unidler'
 
 
 logging.basicConfig(level=os.environ.get('LOG_LEVEL', 'DEBUG'))
 log = logging.getLogger('unidler')
 
 
+def run(host='0.0.0.0', port=8080):
+    try:
+        config.load_incluster_config()
+    except:
+        config.load_kube_config()
+
+    unidler = UnidlerServer((host, port), RequestHandler)
+    log.info(f'Unidler listening on {host}:{port}')
+    unidler.serve_forever()
+
+
+class UnidlerServer(ThreadingMixIn, HTTPServer):
+    pass
+
+
 class RequestHandler(BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        hostname = self.headers.get('X-Forwarded-Host')
+
+        if not hostname:
+            return self.respond(200, 'OK')
+
+        log.info(f'Received {self.requestline} for host {hostname}')
+
+        try:
+            unidle_deployment(hostname)
+            log.info('Unidled {hostname}')
+            self.respond(503, 'Unidling, please try again', {
+                'Retry-After': 10})
+
+        except (DeploymentNotFound, IngressNotFound) as not_found:
+            log.error(not_found)
+            self.respond(404, not_found)
+
+        except kubernetes.client.rest.ApiException as error:
+            log.error(error)
+            self.respond(500, error)
 
     def do_HEAD(self):
         self.respond(200)
 
-    def do_GET(self):
-        log.debug(self.requestline)
-        log.debug(self.headers)
-
-        self.cache_request()
-        self.mark_unidling()
-        # self.restore_replicas()
-        # self.restore_ingress()
-        # self.unmark_idled()
-
-        self.respond(200, 'OK')
-
-    def cache_request(self):
-        pass
-
-    def mark_unidling(self):
-        ingress_host = self.headers['Host']
+    def do_POST(self):
+        self.do_GET()
 
     def respond(self, status, body=None, headers={}):
         self.send_response(status)
@@ -48,14 +83,134 @@ class RequestHandler(BaseHTTPRequestHandler):
             self.wfile.write(str(body).encode('utf-8'))
 
 
-class UnidlerServer(ThreadingMixIn, HTTPServer):
+class DeploymentNotFound(Exception):
     pass
 
 
-def run(host='0.0.0.0', port=8080):
-    unidler = UnidlerServer((host, port), RequestHandler)
-    print(f'Unidler listening on {host}:{port}')
-    unidler.serve_forever()
+class IngressNotFound(Exception):
+    pass
+
+
+def unidle_deployment(hostname):
+    ingresses = build_ingress_lookup()
+
+    with ingress_for_host(hostname, ingresses) as ing:
+        with deployment_for_ingress(ing) as deployment:
+            restore_replicas(deployment)
+            unmark_idled(deployment)
+            enable_ingress(ing)
+
+    with ingress(UNIDLER, 'default', ingresses) as unidler_ingress:
+        remove_host_rule(hostname, unidler_ingress)
+
+
+def build_ingress_lookup():
+    ingresses = client.ExtensionsV1beta1Api().list_ingress_for_all_namespaces()
+    return dict(
+        ((ingress.metadata.name, ingress.metadata.namespace), ingress)
+        for ingress in ingresses.items)
+
+
+@contextlib.contextmanager
+def ingress_for_host(hostname, ingresses):
+    for ingress in ingresses.values():
+        name = ingress.metadata.name
+        namespace = ingress.metadata.namespace
+
+        if (name, namespace) == (UNIDLER, 'default'):
+            continue
+
+        for rule in ingress.spec.rules:
+            if rule.host == hostname:
+                log.debug(
+                    f'Found ingress for {hostname}: {name} '
+                    f'in namespace {namespace}')
+                yield ingress
+                return write_ingress_changes(ingress)
+
+    raise IngressNotFound(f'Ingress for host {hostname} not found')
+
+
+def write_ingress_changes(ingress):
+    log.debug(
+        f'Writing changes to ingress {ingress.metadata.name} '
+        f'in namespace {ingress.metadata.namespace}')
+    client.ExtensionsV1beta1Api().patch_namespaced_ingress(
+        ingress.metadata.name,
+        ingress.metadata.namespace,
+        ingress)
+
+
+@contextlib.contextmanager
+def deployment_for_ingress(ingress):
+    name = ingress.metadata.name
+    namespace = ingress.metadata.namespace
+
+    try:
+        deployment = client.AppsV1beta1Api().read_namespaced_deployment(
+            name,
+            namespace)
+        log.debug(f'Found deployment {name} in namespace {namespace}')
+
+        yield deployment
+
+        write_changes(deployment)
+
+    except kubernetes.client.rest.ApiException as error:
+        raise DeploymentNotFound(f'Deployment {name} not found in {namespace}')
+
+
+def write_changes(deployment):
+    log.debug(
+        f'Writing changes to deployment {deployment.metadata.name} '
+        f'in namespace {deployment.metadata.namespace}')
+    client.AppsV1beta1Api().patch_namespaced_deployment(
+        deployment.metadata.name,
+        deployment.metadata.namespace,
+        deployment)
+
+
+def restore_replicas(deployment):
+    idled_at, replicas = deployment.metadata.annotations[IDLED_AT].split(',')
+    log.debug(f'Restoring {replicas} replicas')
+    deployment.spec.replicas = int(replicas)
+
+
+def enable_ingress(ingress):
+    log.debug('Enabling ingress')
+    ingress.metadata.annotations[INGRESS_CLASS] = 'nginx'
+
+
+def unmark_idled(deployment):
+    log.debug('Removing idled annotation and label')
+
+    deployment.metadata.labels = dict(
+        filter(
+            lambda label: label[0] != IDLED,
+            deployment.metadata.labels.items()))
+
+    deployment.metadata.annotations = dict(
+        filter(
+            lambda annotation: annotation[0] != IDLED_AT,
+            deployment.metadata.annotations.items()))
+
+
+@contextlib.contextmanager
+def ingress(name, namespace, ingresses):
+    ingress = ingresses[(name, namespace)]
+    yield ingress
+    write_ingress_changes(ingress)
+
+
+def remove_host_rule(hostname, ingress):
+    log.debug(
+        f'Removing host rules for {hostname} '
+        f'from ingress {ingress.metadata.name} '
+        f'in namespace {ingress.metadata.namespace}')
+    ingress.spec.rules = list(
+        filter(
+            lambda rule: rule.host != hostname,
+            ingress.spec.rules))
 
 
 if __name__ == '__main__':

--- a/unidler.py
+++ b/unidler.py
@@ -55,7 +55,11 @@ class RequestHandler(BaseHTTPRequestHandler):
         try:
             unidle_deployment(hostname)
             log.info('Unidled {hostname}')
-            self.respond(503, 'Unidling, please try again', {
+            url = f'//{hostname}{self.path}'
+            body = f'Unidling, please <a href="{url}">try again</a>'
+            self.respond(503, body, {
+                'Content-type': 'text/html',
+                'Refresh': f'10; {url}',
                 'Retry-After': 10})
 
         except (DeploymentNotFound, IngressNotFound) as not_found:

--- a/unidler.py
+++ b/unidler.py
@@ -164,7 +164,7 @@ def write_changes(deployment):
     log.debug(
         f'Writing changes to deployment {deployment.metadata.name} '
         f'in namespace {deployment.metadata.namespace}')
-    client.AppsV1beta1Api().patch_namespaced_deployment(
+    client.AppsV1beta1Api().replace_namespaced_deployment(
         deployment.metadata.name,
         deployment.metadata.namespace,
         deployment)
@@ -183,16 +183,8 @@ def enable_ingress(ingress):
 
 def unmark_idled(deployment):
     log.debug('Removing idled annotation and label')
-
-    deployment.metadata.labels = dict(
-        filter(
-            lambda label: label[0] != IDLED,
-            deployment.metadata.labels.items()))
-
-    deployment.metadata.annotations = dict(
-        filter(
-            lambda annotation: annotation[0] != IDLED_AT,
-            deployment.metadata.annotations.items()))
+    del deployment.metadata.labels[IDLED]
+    del deployment.metadata.annotations[IDLED_AT]
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Simple HTTP server uses `X-Forwarded-Host` header on HTTP request to lookup ingress of idled deployment and unidles it.

Unidling is the reverse of idling, namely
1. Remove `idle` label and `mojanalytics.xyz/idled-at` annotation
2. Re-enable ingress by setting `kubernetes.io/ingress.class` annotation to `nginx`
3. Restore deployment replicas to the number stored in the `idled-at` annotation
4. Remove the host rule from the unidler ingress

No provision is made yet for caching requests and forwarding them to the unidled deployment.
Also, there is likely to be a race condition when multiple requests are received in a short period and multiple unidler threads attempt to unidle the same deployment at once. This will be dealt with in a later PR.