### PR TITLE
Automatically redirect (with Javascript) when idled deployment is ready

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,6 @@ ADD requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
 ADD unidler.py unidler.py
+ADD please_wait.html please_wait.html
 
 CMD ["python", "unidler.py"]

--- a/please_wait.html
+++ b/please_wait.html
@@ -20,11 +20,9 @@
     xhr.onreadystatechange = function () {
       if (xhr.readyState === XMLHttpRequest.DONE) {
         if (xhr.status >= 200 && xhr.status < 400) {
-          // target is ready, so redirect
           window.location = URL;
 
         } else {
-          // check again after a delay
           window.setTimeout(redirect_when_ready, DELAY);
         }
       }

--- a/please_wait.html
+++ b/please_wait.html
@@ -17,8 +17,7 @@
     xhr.open('GET', url, true);
 
     xhr.onreadystatechange = function () {
-      if (xhr.readyState === 4) {
-        // request is DONE
+      if (xhr.readyState === XMLHttpRequest.DONE) {
         if (xhr.status >= 200 && xhr.status < 400) {
           // target is ready, so redirect
           window.location = url;

--- a/please_wait.html
+++ b/please_wait.html
@@ -5,26 +5,27 @@
     <title>Unidling, please wait</title>
   </head>
   <body>
-    <h1>Unidling, please wait a few seconds</h1>
+    <h1>Unidling, please wait</h1>
+    <p>You will be redirected automatically when unidling is complete.</p>
     <script>
 (function () {
 
-  var delay = 3000;
-  var url = 'UNIDLER_REDIRECT_URL';
+  var DELAY = 3000;
+  var URL = 'UNIDLER_REDIRECT_URL';
 
   function redirect_when_ready() {
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', url, true);
+    xhr.open('GET', URL, true);
 
     xhr.onreadystatechange = function () {
       if (xhr.readyState === XMLHttpRequest.DONE) {
         if (xhr.status >= 200 && xhr.status < 400) {
           // target is ready, so redirect
-          window.location = url;
+          window.location = URL;
 
         } else {
           // check again after a delay
-          window.setTimeout(redirect_when_ready, delay);
+          window.setTimeout(redirect_when_ready, DELAY);
         }
       }
     };
@@ -32,7 +33,7 @@
     xhr.send();
   }
 
-  window.setTimeout(redirect_when_ready, delay);
+  window.setTimeout(redirect_when_ready, DELAY);
 })();
     </script>
   </body>

--- a/please_wait.html
+++ b/please_wait.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Unidling, please wait</title>
+  </head>
+  <body>
+    <h1>Unidling, please wait a few seconds</h1>
+    <script>
+(function () {
+
+  var delay = 3000;
+  var url = 'UNIDLER_REDIRECT_URL';
+
+  function redirect_when_ready() {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', url, true);
+
+    xhr.onreadystatechange = function () {
+      if (xhr.readyState === 4) {
+        // request is DONE
+        if (xhr.status >= 200 && xhr.status < 400) {
+          // target is ready, so redirect
+          window.location = url;
+
+        } else {
+          // check again after a delay
+          window.setTimeout(redirect_when_ready, delay);
+        }
+      }
+    };
+
+    xhr.send();
+  }
+
+  window.setTimeout(redirect_when_ready, delay);
+})();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
What:

* Respond with an HTML page with embedded Javascript which requests idled deployment URL and redirects to it if a success response (200 - 399) is received. This means users should be able to just browse to the idled app, get a "Please wait" message and just wait until the browser refreshes and shows the unidled app. No more 503s.