### PR TITLE
Ability to configure Ingress class name

### DIFF
--- a/test/test_unidler.py
+++ b/test/test_unidler.py
@@ -95,7 +95,7 @@ def test_enable_ingress(ingress):
 
     unidler.enable_ingress(ingress)
 
-    assert ingress.metadata.annotations[INGRESS_CLASS] == 'nginx'
+    assert ingress.metadata.annotations[INGRESS_CLASS] == 'istio'
 
 
 def test_restore_replicas(deployment):
@@ -243,7 +243,7 @@ class TestRequestHandler(object):
             lambda rule: rule.host == HOSTNAME,
             unidler_ingress.spec.rules))) == 0
 
-        assert ingress.metadata.annotations[INGRESS_CLASS] == 'nginx'
+        assert ingress.metadata.annotations[INGRESS_CLASS] == 'istio'
 
         assert HOSTNAME not in RequestHandler.unidling
 

--- a/unidler.py
+++ b/unidler.py
@@ -21,6 +21,7 @@ from kubernetes.client.models import (
 IDLED = 'mojanalytics.xyz/idled'
 IDLED_AT = 'mojanalytics.xyz/idled-at'
 INGRESS_CLASS = 'kubernetes.io/ingress.class'
+INGRESS_CLASS_NAME = os.environ.get('INGRESS_CLASS_NAME', 'istio')
 UNIDLER = 'unidler'
 UNIDLER_NAMESPACE = 'default'
 
@@ -227,7 +228,7 @@ def remove_host_rule(hostname, ingress):
 
 
 def enable_ingress(ingress):
-    ingress.metadata.annotations[INGRESS_CLASS] = 'nginx'
+    ingress.metadata.annotations[INGRESS_CLASS] = INGRESS_CLASS_NAME
 
 
 def please_wait(hostname):


### PR DESCRIPTION
This was hardcoded to "nginx" but it's now read from the
`INGRESS_CLASS_NAME` environment variable (default: `istio`)