### PR TITLE
Use `Host` header instead of `X-Forwarded-Host` to determine pod to unidle

### DIFF
--- a/test/test_unidler.py
+++ b/test/test_unidler.py
@@ -185,7 +185,7 @@ class TestRequestHandler(object):
         apps.read_namespaced_deployment.return_value = deployment
 
         response = self.handle_request('GET', '/', {
-            'X-Forwarded-Host': HOSTNAME,
+            'Host': HOSTNAME,
         })
         assert response.status_code == HTTPStatus.ACCEPTED
         assert IDLED not in deployment.metadata.labels
@@ -208,7 +208,7 @@ class TestRequestHandler(object):
         RequestHandler.unidling[HOSTNAME] = unidling
 
         response = self.handle_request('GET', '/', {
-            'X-Forwarded-Host': HOSTNAME,
+            'Host': HOSTNAME,
         })
 
         api = client.AppsV1beta1Api.return_value
@@ -236,7 +236,7 @@ class TestRequestHandler(object):
         RequestHandler.unidling[HOSTNAME] = unidling
 
         response = self.handle_request('GET', '/', {
-            'X-Forwarded-Host': HOSTNAME,
+            'Host': HOSTNAME,
         })
 
         assert len(list(filter(

--- a/unidler.py
+++ b/unidler.py
@@ -49,8 +49,9 @@ class RequestHandler(BaseHTTPRequestHandler):
     unidling = {}
 
     def do_GET(self):
-        hostname = self.headers.get('X-Forwarded-Host', UNIDLER)
+        log.debug(f'HEADERS: {self.headers}')
 
+        hostname = self.headers.get('Host', UNIDLER)
         if hostname.startswith(UNIDLER):
             log.debug('No hostname specified')
             self.respond(HTTPStatus.NO_CONTENT, '')


### PR DESCRIPTION
**NOTE**: This may be a breaking change and incompatible with nginx.
        Requests going through Istio's Envoy proxy doesn't have this
        header.