### PR TITLE
Cope when 'idled-at' annotation is not there

### DIFF
--- a/unidler.py
+++ b/unidler.py
@@ -175,13 +175,13 @@ def restore_replicas(deployment):
     annotation = deployment.metadata.annotations.get(IDLED_AT)
 
     if annotation is not None:
-        idled_at, replicas = annotation.split(',')
-        log.debug(f'Restoring {replicas} replicas')
-        deployment.spec.replicas = int(replicas)
-
+        replicas = annotation.split(',')[1]
     else:
-        # TODO Assume a default of 1?
-        log.error('Deployment has no idled-at annotation')
+        log.error('Deployment has no idled-at annotation - assuming 1 replica')
+        replicas = 1
+
+    log.debug(f'Restoring {replicas} replicas')
+    deployment.spec.replicas = int(replicas)
 
 
 def unmark_idled(deployment):


### PR DESCRIPTION
This fixes one particular situation I saw with my own rstudio on dev.